### PR TITLE
Fix eth_maxPriorityFeePerGas test

### DIFF
--- a/tests/test-max-priority-fee-per-gas-rpc.ts
+++ b/tests/test-max-priority-fee-per-gas-rpc.ts
@@ -16,7 +16,7 @@ describeWithMetachain('Metachain RPC (Max Priority Fee Per Gas)', (context) => {
                 await sendTransaction(context, {
                     to: '0x0000000000000000000000000000000000000000',
                     data: '0x',
-                    maxFeePerGas: context.web3.utils.numberToHex(INITIAL_BASE_FEE),
+                    maxFeePerGas: context.web3.utils.numberToHex(150_000_000_000),
                     maxPriorityFeePerGas: context.web3.utils.numberToHex(priority_fees[p]),
                     nonce: nonce,
                     gas: '0x5208',


### PR DESCRIPTION
## Summary

- Max fee per gas is the absolute highest fees that the sender is willing to pay. Thus the miner reward fees will be zero if set at initial block base fees.
- With the correct fixes on the node, the test is now incorrect and this PR fixes the test.
